### PR TITLE
JSITE-96: Update caching headers

### DIFF
--- a/nginx.tpl.conf
+++ b/nginx.tpl.conf
@@ -36,12 +36,37 @@ http {
     server {
         listen 80 default_server;
 
+        error_page   404  /404.html;
+
         rewrite ^/assets/white_paper.* https://github.com/jibrelnetwork/white_paper permanent;
 
         location / {
             root /app;
-            index index.html;
-            try_files $uri $uri.html $uri/ /index.html;
+            try_files $uri $uri/ =404;
+
+            location ~* \.(?:manifest|appcache|html?|xml|json)$ {
+                expires -1;
+                add_header Cache-Control "public, must-revalidate";
+            }
+
+            location ~* /img/[^/]+\.(?:jpg|jpeg|gif|png|ico|svg|webp)$ {
+                expires 1y;
+                add_header Cache-Control "public, immutable";
+            }
+
+            location ~* /(?:blog|content|cover|partners|misc)/[^/]+\.(?:jpg|jpeg|gif|png|ico|svg|webp)$ {
+                expires 1d;
+                add_header Cache-Control "public";
+            }
+
+            location ~* \.(?:css|js)$ {
+                expires 1y;
+                add_header Cache-Control "public, immutable";
+            }
+
+            location = /version.txt {
+                expires -1;
+            }
         }
 
         location /status {

--- a/nginx.tpl.conf
+++ b/nginx.tpl.conf
@@ -49,12 +49,17 @@ http {
                 add_header Cache-Control "public, must-revalidate";
             }
 
-            location ~* /img/[^/]+\.(?:jpg|jpeg|gif|png|ico|svg|webp)$ {
+            location ~* ^/assets/img/[^/]+\.(?:jpg|jpeg|gif|png|ico|svg|webp)$ {
                 expires 1y;
                 add_header Cache-Control "public, immutable";
             }
 
-            location ~* /(?:blog|content|cover|partners|misc)/[^/]+\.(?:jpg|jpeg|gif|png|ico|svg|webp)$ {
+            location ~* ^/assets/img/(?:blog|content|cover|partners)/[^/]+\.(?:jpg|jpeg|gif|png|ico|svg|webp)$ {
+                expires 1d;
+                add_header Cache-Control "public";
+            }
+
+            location ~* ^/assets/misc/[^/]+\.(?:jpg|jpeg|gif|png|ico|svg|webp)$ {
                 expires 1d;
                 add_header Cache-Control "public";
             }

--- a/nginx.tpl.conf
+++ b/nginx.tpl.conf
@@ -64,7 +64,7 @@ http {
                 add_header Cache-Control "public";
             }
 
-            location ~* \.(?:css|js)$ {
+            location ~* \.[a-f0-9]{8}\.(?:css|js)$ {
                 expires 1y;
                 add_header Cache-Control "public, immutable";
             }


### PR DESCRIPTION
The new caching headers basically say:

- HTML pages, manifest files and data are **not cached** on client-side (or intermediary servers) and must always be revalidated against source server
- images provided in root of `/assets/img` directory include hash in their name, so could be **cached indefinitely**
- images in subdirectories do not include hash, but they change rarely and are used only inside content, so they could be safely **cached for 1d**
- all css and js include hash, so they could be **cached indefinitely**
- version.txt must **never be cached**